### PR TITLE
Upgraded 4 extensions, increase memory limit, force a task to retry, and setting article path variable

### DIFF
--- a/config/MezaCoreExtensions.yml
+++ b/config/MezaCoreExtensions.yml
@@ -342,7 +342,7 @@ list:
   - name: ApprovedRevs
     repo: https://github.com/wikimedia/mediawiki-extensions-ApprovedRevs.git
     # Use this commit until a release tag for v1.0 is created
-    version: tags/1.2.2
+    version: tags/1.7.2
     config: |
       $egApprovedRevsAutomaticApprovals = false;
 

--- a/config/MezaCoreExtensions.yml
+++ b/config/MezaCoreExtensions.yml
@@ -358,8 +358,8 @@ list:
 
   # Verify 34.x functionality
   - name: WatchAnalytics
-    repo: https://github.com/wikimedia/mediawiki-extensions-WatchAnalytics.git
-    version: tags/4.1.0
+    repo: https://github.com/djflux/WatchAnalytics.git
+    version: "7f9c0b74f815f7cb55fe2b7ea6b8bd3bcc8f4357"
     config: |
       $egPendingReviewsEmphasizeDays = 10; // makes Pending Reviews shake after X days
 

--- a/config/MezaCoreExtensions.yml
+++ b/config/MezaCoreExtensions.yml
@@ -240,12 +240,12 @@ list:
     version: "{{ mediawiki_default_branch }}"
     composer_merge: True
 
-  - name: Thanks
-    repo: https://github.com/wikimedia/mediawiki-extensions-Thanks.git
-    version: "{{ mediawiki_default_branch }}"
-    config: |
-      $wgThanksConfirmationRequired = false;
-
+#   - name: Thanks
+#     repo: https://github.com/wikimedia/mediawiki-extensions-Thanks.git
+#     version: "{{ mediawiki_default_branch }}"
+#     config: |
+#       $wgThanksConfirmationRequired = false;
+#
   - name: RevisionSlider
     repo: https://github.com/wikimedia/mediawiki-extensions-RevisionSlider.git
     version: "{{ mediawiki_default_branch }}"

--- a/config/MezaCoreExtensions.yml
+++ b/config/MezaCoreExtensions.yml
@@ -324,7 +324,7 @@ list:
 
   - name: HeaderTabs
     repo: https://github.com/wikimedia/mediawiki-extensions-HeaderTabs.git
-    version: tags/1.2
+    version: tags/2.2.1
     config: |
       $wgHeaderTabsEditTabLink = false;
       $wgHeaderTabsRenderSingleTab = true;

--- a/config/MezaCoreExtensions.yml
+++ b/config/MezaCoreExtensions.yml
@@ -252,7 +252,7 @@ list:
 
   - name: CollapsibleVector
     repo: https://github.com/wikimedia/mediawiki-extensions-CollapsibleVector
-    version: "{{ mediawiki_default_branch }}"
+    version: 7b71b1b04cc77eb4621e55b3dda6b9e15f4dd029
 
   - name: SimpleMathJax
     repo: https://github.com/jamesmontalvo3/SimpleMathJax.git

--- a/src/roles/apache-php/tasks/mssql_driver_for_php.yml
+++ b/src/roles/apache-php/tasks/mssql_driver_for_php.yml
@@ -10,6 +10,10 @@
 
 # Install ODBC driver
 - name: install mssql-server repo (CentOS, RedHat)
+  retries: 5
+  delay: 5
+  register: repo_result
+  until: repo_result is success
   get_url:
     url: https://packages.microsoft.com/config/rhel/8/prod.repo
     dest: /etc/yum.repos.d/mssql-release.repo

--- a/src/roles/apache-php/tasks/mssql_driver_for_php.yml
+++ b/src/roles/apache-php/tasks/mssql_driver_for_php.yml
@@ -11,7 +11,7 @@
 # Install ODBC driver
 - name: install mssql-server repo (CentOS, RedHat)
   get_url:
-    url: https://packages.microsoft.com/config/rhel/7/prod.repo
+    url: https://packages.microsoft.com/config/rhel/8/prod.repo
     dest: /etc/yum.repos.d/mssql-release.repo
   when: ansible_distribution in ['CentOS', 'RedHat']
 

--- a/src/roles/apache-php/templates/php.ini.j2
+++ b/src/roles/apache-php/templates/php.ini.j2
@@ -393,7 +393,8 @@ max_input_vars = {{ php_max_input_vars }}
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit
-memory_limit = 128M
+;memory_limit = 128M ; Original value. Probably should set this as a variable to allow this to be set manually
+memory_limit = 1024M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -287,8 +287,8 @@ $wgScriptExtension = ".php";
 $wgStylePath = "$wgScriptPath/skins";
 $wgResourceBasePath = $wgScriptPath;
 
-
-
+## This is the base URL that will be used to construct all internal links. Without this, the title will append to the end of the URL when switching wikis in a wiki farm
+$wgArticlePath = "/$wikiId/index.php/$1";
 
 
 


### PR DESCRIPTION
### Changes

* Removed Thanks extension
* Bumped CollapsibleVector to a newer commit that supports MW 1.35
* Bumped HeaderTabs to a newer commit that supports MW 1.35
* Bumped ApprovedRevs to a commit with better support for MW 1.35
* Force retry for failed task trying to install ODBC driver
* Increased memory limit
* Set $wgArticlePath to fix URL issue
