### PR TITLE
fix: bump to latest SAML auth

### DIFF
--- a/config/MezaCoreExtensions.yml
+++ b/config/MezaCoreExtensions.yml
@@ -484,4 +484,3 @@ list:
   - name: NumerAlpha
     repo: https://github.com/wikimedia/mediawiki-extensions-NumerAlpha.git
     version: "{{ mediawiki_default_branch }}"
-    legacy_load: True

--- a/src/roles/base/tasks/main.yml
+++ b/src/roles/base/tasks/main.yml
@@ -88,6 +88,7 @@
     ACCEPT_EULA: 'y'
   tags:
   - latest
+  - upgrade-packages
 
 # FIXME #807: for RedHat may need to enable "Optional RPMs"
 - name: Ensure EPEL installed via epel-release package (CentOS only)

--- a/src/roles/mediawiki/templates/LocalSettings.php.j2
+++ b/src/roles/mediawiki/templates/LocalSettings.php.j2
@@ -9,8 +9,7 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 /**
  *  TABLE OF CONTENTS
  *
-{% if saml_secret is defined %} *    0) SAML AUTH
-{% endif %} *    1) WIKI-SPECIFIC SETUP
+ *    1) WIKI-SPECIFIC SETUP
  *    2) DEBUG
  *    3) PATH SETUP
  *    4) EMAIL
@@ -22,17 +21,6 @@ if ( !defined( 'MEDIAWIKI' ) ) {
  *
  **/
 
-{% if saml_secret is defined %}
-/**
- *  0) SAML AUTH
- *
- *  Perform authentication up front.
- *
- **/
-require "{{ m_deploy }}/samlLocalSettings.php";
-
-
-{% endif %}
 
 /**
  *  1) WIKI-SPECIFIC SETUP
@@ -58,6 +46,17 @@ else {
 	$wikiId = strtolower( $uriParts[1] ); // URI has leading slash, so $uriParts[0] is empty string
 
 }
+
+
+{% if saml_secret is defined %}
+/**
+ *  0) SAML AUTH
+ *
+ *  Perform authentication up front, immediately after $wikiId is setup.
+ *
+ **/
+require "{{ m_deploy }}/samlLocalSettings.php";
+{% endif %}
 
 
 {% if wiki_id_redirects is defined and wiki_id_redirects|length > 0 %}

--- a/src/roles/saml/tasks/main.yml
+++ b/src/roles/saml/tasks/main.yml
@@ -86,7 +86,7 @@
   git:
     repo: https://github.com/wikimedia/mediawiki-extensions-PluggableAuth.git
     dest: "{{ m_mediawiki }}/extensions/PluggableAuth"
-    version: "e269a87928922acde2d7399c97a40a60f040c789" # "{{ saml_mw_extension_version }}"
+    version: "tags/6.3" # "{{ saml_mw_extension_version }}"
     umask: "0002"
   tags:
     - latest
@@ -100,7 +100,7 @@
   git:
     repo: https://github.com/wikimedia/mediawiki-extensions-SimpleSAMLphp.git
     dest: "{{ m_mediawiki }}/extensions/SimpleSAMLphp"
-    version: "154a27271e49028e43e78a10c473ac567ba5b51f" # "{{ saml_mw_extension_version }}"
+    version: "tags/5.0.1" # "{{ saml_mw_extension_version }}"
     umask: "0002"
   tags:
     - latest

--- a/src/roles/saml/tasks/main.yml
+++ b/src/roles/saml/tasks/main.yml
@@ -86,7 +86,7 @@
   git:
     repo: https://github.com/wikimedia/mediawiki-extensions-PluggableAuth.git
     dest: "{{ m_mediawiki }}/extensions/PluggableAuth"
-    version: "e30458b2fea128394ea1c87cf880b1d85b3b0f65" # "{{ saml_mw_extension_version }}"
+    version: "e269a87928922acde2d7399c97a40a60f040c789" # "{{ saml_mw_extension_version }}"
     umask: "0002"
   tags:
     - latest
@@ -98,9 +98,9 @@
   environment:
     TMPDIR: "{{ m_tmp }}"
   git:
-    repo: https://github.com/jamesmontalvo3/mediawiki-extensions-SimpleSAMLphp.git
+    repo: https://github.com/wikimedia/mediawiki-extensions-SimpleSAMLphp.git
     dest: "{{ m_mediawiki }}/extensions/SimpleSAMLphp"
-    version: "merge-test" # "{{ saml_mw_extension_version }}"
+    version: "154a27271e49028e43e78a10c473ac567ba5b51f" # "{{ saml_mw_extension_version }}"
     umask: "0002"
   tags:
     - latest

--- a/src/roles/saml/templates/NonMediaWikiSimpleSamlAuth.php.j2
+++ b/src/roles/saml/templates/NonMediaWikiSimpleSamlAuth.php.j2
@@ -43,7 +43,7 @@ class NonMediaWikiSimpleSamlAuth {
 	 */
 	private static function init() {
 		global $wgSimpleSAMLphp_InstallDir;
-		global $wgSimpleSAMLphp_AuthSourceId;
+		global $wgPluggableAuth_Config;
 		global $wgSessionName;
 		global $wgSessionsInMemcached;
 		global $wgSessionsInObjectCache;
@@ -63,7 +63,9 @@ class NonMediaWikiSimpleSamlAuth {
 		// Load the simpleSamlPhp service
 		require_once rtrim( $wgSimpleSAMLphp_InstallDir, DIRECTORY_SEPARATOR ) .
 			DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . '_autoload.php';
-		self::$as = new SimpleSAML\Auth\Simple( $wgSimpleSAMLphp_AuthSourceId );
+		self::$as = new SimpleSAML\Auth\Simple(
+			$wgPluggableAuth_Config['Login with SAML']['data']['authSourceId']
+		);
 		self::$initialised = is_object( self::$as );
 		return self::$initialised;
 	}

--- a/src/roles/saml/templates/NonMediaWikiSimpleSamlAuth.php.j2
+++ b/src/roles/saml/templates/NonMediaWikiSimpleSamlAuth.php.j2
@@ -43,7 +43,6 @@ class NonMediaWikiSimpleSamlAuth {
 	 */
 	private static function init() {
 		global $wgSimpleSAMLphp_InstallDir;
-		global $wgPluggableAuth_Config;
 		global $wgSessionName;
 		global $wgSessionsInMemcached;
 		global $wgSessionsInObjectCache;
@@ -63,9 +62,7 @@ class NonMediaWikiSimpleSamlAuth {
 		// Load the simpleSamlPhp service
 		require_once rtrim( $wgSimpleSAMLphp_InstallDir, DIRECTORY_SEPARATOR ) .
 			DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . '_autoload.php';
-		self::$as = new SimpleSAML\Auth\Simple(
-			$wgPluggableAuth_Config['Login with SAML']['data']['authSourceId']
-		);
+		self::$as = new SimpleSAML\Auth\Simple('default-sp');
 		self::$initialised = is_object( self::$as );
 		return self::$initialised;
 	}

--- a/src/roles/saml/templates/SAMLConfig.php.j2
+++ b/src/roles/saml/templates/SAMLConfig.php.j2
@@ -6,12 +6,16 @@ $wgSessionName = "PHPSESSID";
 // Should login occur automatically when a user visits the wiki?
 $wgPluggableAuth_EnableAutoLogin = true;
 
-// SAML attributes. These are edited by /opt/meza/src/scripts/saml.sh
-// when setting up SAML auth.
-$wgSimpleSAMLphp_UsernameAttribute = '{{ saml_public.idp_username_attr }}';
-$wgSimpleSAMLphp_RealNameAttribute = '{{ saml_public.idp_realname_attr }}';
-$wgSimpleSAMLphp_EmailAttribute = '{{ saml_public.idp_email_attr }}';
 
 // SimpleSamlPhp settings
 $wgSimpleSAMLphp_InstallDir = '{{ m_install }}/simplesamlphp';
-$wgSimpleSAMLphp_AuthSourceId = 'default-sp';
+$wgPluggableAuth_Config['Login with SAML'] = [
+	'plugin' => 'SimpleSAMLphp',
+	'data' => [
+		'authSourceId' => 'default-sp',
+		'usernameAttribute' => '{{ saml_public.idp_username_attr }}',
+		'realNameAttribute' => '{{ saml_public.idp_realname_attr }}',
+		'emailAttribute' => '{{ saml_public.idp_email_attr }}'
+	]
+    // add `groupsyncs` in local config
+];

--- a/src/roles/saml/templates/SAMLConfig.php.j2
+++ b/src/roles/saml/templates/SAMLConfig.php.j2
@@ -1,7 +1,6 @@
 <?php
 
-// make sure that session storage matches to the one used in simplesaml most likely default PHPSESSID
-$wgSessionName = "PHPSESSID";
+$wgSessionName = "wiki_session_$wikiId";
 
 // Should login occur automatically when a user visits the wiki?
 $wgPluggableAuth_EnableAutoLogin = true;

--- a/src/roles/saml/templates/SAMLConfig.php.j2
+++ b/src/roles/saml/templates/SAMLConfig.php.j2
@@ -9,13 +9,3 @@ $wgPluggableAuth_EnableAutoLogin = true;
 
 // SimpleSamlPhp settings
 $wgSimpleSAMLphp_InstallDir = '{{ m_install }}/simplesamlphp';
-$wgPluggableAuth_Config['Login with SAML'] = [
-	'plugin' => 'SimpleSAMLphp',
-	'data' => [
-		'authSourceId' => 'default-sp',
-		'usernameAttribute' => '{{ saml_public.idp_username_attr }}',
-		'realNameAttribute' => '{{ saml_public.idp_realname_attr }}',
-		'emailAttribute' => '{{ saml_public.idp_email_attr }}'
-	]
-    // add `groupsyncs` in local config
-];


### PR DESCRIPTION
- Use latest auth extensions
- Move some of auth config out of meza and have people do it in local config
- Move auth setup just slightly lower in LocalSettings.php so `$wikiId` variable exists and auth config can be based on it