### PR TITLE
fix!: remove Extension:Approvedrevs

### DIFF
--- a/config/MezaCoreExtensions.yml
+++ b/config/MezaCoreExtensions.yml
@@ -339,13 +339,6 @@ list:
     repo: https://github.com/enterprisemediawiki/Wiretap.git
     version: tags/0.2.0
 
-  - name: ApprovedRevs
-    repo: https://github.com/wikimedia/mediawiki-extensions-ApprovedRevs.git
-    # Use this commit until a release tag for v1.0 is created
-    version: tags/1.7.2
-    config: |
-      $egApprovedRevsAutomaticApprovals = false;
-
   # Verify 34.x functionality
   - name: ImagesLoaded
     repo: https://github.com/enterprisemediawiki/ImagesLoaded.git


### PR DESCRIPTION
ApprovedRevs conflicts with MyVariables for some reason, such that a specific loading order is required. To facilitate this, Extension:ApprovedRevs is moved out of MezaCoreExtensions and must be individually specified by users. 

Ultimately Meza wants to get out of the business of requiring extensions, and allow users to choose, so this is a (small) step in that direction, too.