### PR TITLE
Adjust packages for MW 1.35/RL8

### DIFF
--- a/config/RedHat.yml
+++ b/config/RedHat.yml
@@ -8,58 +8,18 @@ package_openssh_client: openssh-clients
 package_cron: cronie
 package_apache: httpd-devel
 package_php_apache_deps7:
-  - zlib-devel
-  - sqlite-devel
-  - bzip2-devel
-  - pcre-devel
-  - openssl-devel
-  - curl-devel
-  - libxml2-devel
-  - libXpm-devel
-  - gmp-devel
-  - libicu-devel
-  - t1lib-devel
-  - aspell-devel
-  - libcurl-devel
-  - libjpeg-devel
-  - libvpx-devel
-  - libpng-devel
-  - freetype-devel
-  - readline-devel
-  - libtidy-devel
-  - libmcrypt-devel
-  - pam-devel
   - sendmail
   - sendmail-cf
   - m4
   - xz-libs
   - mariadb-libs
-package_php_apache_deps8:
   - zlib-devel
-  - sqlite-devel
-  - bzip2-devel
-  - pcre-devel
-  - openssl-devel
-  - curl-devel
-  - libxml2-devel
-  - libXpm-devel
-  - gmp-devel
-  - libicu-devel
-  - t1lib-devel
-  - aspell-devel
-  - libcurl-devel
-  - libjpeg-devel
-  - libvpx-devel
-  - libpng-devel
-  - freetype-devel
-  - readline-devel
-  - libtidy-devel
-  - libmcrypt-devel
-  - pam-devel
+package_php_apache_deps8:
   - sendmail
   - sendmail-cf
   - m4
   - xz-libs
+  - zlib-devel
 package_java: java-1.8.0-openjdk
 package_python3: python36
 package_python3_pip: python36-pip
@@ -82,7 +42,6 @@ package_lua: [ 'lua', 'lua-devel' ]
 package_imagemagick:
   - ghostscript
   - ImageMagick
-  - ImageMagick-devel
 package_ntp: ntpd
 package_ntp8: chrony
 

--- a/src/roles/apache-php/tasks/php-redhat8.yml
+++ b/src/roles/apache-php/tasks/php-redhat8.yml
@@ -10,6 +10,9 @@
     name: "php5*"
     state: absent
 
+- name: Switch to php 7.4
+  shell: dnf -y module switch-to php:7.4
+
 - name: Ensure PHP packages for Rocky/RHEL8 installed
   package:
     name:
@@ -33,27 +36,22 @@
       - php-ldap
       - php-fpm
       - php-pear
-      - libmemcached-devel
     state: present
+
+- name: install libmemcached-devel
+  dnf:
+    name: libmemcached-devel
+    enablerepo: devel
 
 # PHP memcached extension needed for SAML auth
 - name: Ensure PEAR channel up-to-date
   shell: pear channel-update pecl.php.net
 
+# --configureoptions parameter is not supported in our version of pecl.
 - name: Install memcached PECL packages
   shell: >
-    pecl install
-    --configureoptions
-    'with-libmemcached-dir="no"
-    with-zlib-dir="no"
-    with-system-fastlz="no"
-    enable-memcached-igbinary="no"
-    enable-memcached-msgpack="no"
-    enable-memcached-json="no"
-    enable-memcached-protocol="no"
-    enable-memcached-sasl="yes"
-    enable-memcached-session="yes"'
-    memcached
+    printf 'no\nno\nno\nno\nno\nno\nno\nyes\nyes\n' |
+    pecl install memcached
   ignore_errors: true
   notify:
     - restart apache


### PR DESCRIPTION
Ensure proper packages are installed for RL8

### Changes

* Use PHP7.4 (Otherwise we cannot install composer dependencies)
* Do not install -devel packages that do not appear to be used. The only things we are compiling from source are pecl-memcached and luasandbox.
* Ensure that libmemcached-devel is installed as it is needed
* Do not use --configureoptions with pecl. Support for that is only present in a later version of pecl. Use printf to answer compile options interactively instead.

-----
This work was performed for NASA GRC-ATF by WikiTeq Inc per `NASA SOW #1 (2023-06-09).pdf `– Please contact Richard Evans at NASA GRC-ATF for questions relating to this work.
