### PR TITLE
fix: load balancer variable naming

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -240,9 +240,9 @@ load_balancers_all: >
   ( groups.get('load_balancers', [] ) ) +
   ( groups.get('load_balancers_meza_internal', [] ) ) +
   ( groups.get('load_balancers_meza_external', [] ) ) +
-  ( groups.get('load_balancers_meza_nonmeza', [] ) ) +
-  ( groups.get('load_balancers_meza_nonmeza_internal', [] ) ) +
-  ( groups.get('load_balancers_meza_nonmeza_external', [] ) )
+  ( groups.get('load_balancers_nonmeza', [] ) ) +
+  ( groups.get('load_balancers_nonmeza_internal', [] ) ) +
+  ( groups.get('load_balancers_nonmeza_external', [] ) )
   }}
 
 
@@ -250,14 +250,14 @@ load_balancers_all: >
 load_balancers_internal: >
   {{
   ( groups.get('load_balancers_meza_internal', [] ) ) +
-  ( groups.get('load_balancers_meza_nonmeza_internal', [] ) )
+  ( groups.get('load_balancers_nonmeza_internal', [] ) )
   }}
 
 # Just load balancers for handling external traffic
 load_balancers_external: >
   {{
   ( groups.get('load_balancers_meza_external', [] ) ) +
-  ( groups.get('load_balancers_meza_nonmeza_external', [] ) )
+  ( groups.get('load_balancers_nonmeza_external', [] ) )
   }}
 
 # Just load balancers that handle internal and external

--- a/src/scripts/getmeza.sh
+++ b/src/scripts/getmeza.sh
@@ -65,7 +65,7 @@ if [ -f /etc/redhat-release ]; then
 	done
 
 # if Debian support still desired, add else condition here
-fi 
+fi
 
 # make sure conf-meza exists and has good permissions
 mkdir -p ${INSTALL_DIR}/conf-meza/secret


### PR DESCRIPTION
Commit 45c7cb04 changed how load balancer groups are accessed. This was a good change, but some of the load balancer variables were changed accidentally. e.g.

load_balancers_nonmeza --> load_balancers_meza_nonmeza

This "_meza_nonmeza" ending (a) was applied inconsistently and (b) doesn't make sense as a naming convention.

This commit fixes naming.

### Changes

* Please provide
* a list
* of changes

### Issues

* Closes #123456789 ???
* Addresses #987654321 ???

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
