### PR TITLE
Change WatchAnalytics to fork that implements log_actor patch

### DIFF
--- a/config/MezaCoreExtensions.yml
+++ b/config/MezaCoreExtensions.yml
@@ -351,8 +351,8 @@ list:
 
   # Verify 34.x functionality
   - name: WatchAnalytics
-    repo: https://github.com/djflux/WatchAnalytics.git
-    version: "7f9c0b74f815f7cb55fe2b7ea6b8bd3bcc8f4357"
+    repo: https://github.com/V-Brooks/WatchAnalytics.git
+    version: "48063e29bd2d0dceaea08640d5f408ea817c1308"
     config: |
       $egPendingReviewsEmphasizeDays = 10; // makes Pending Reviews shake after X days
 


### PR DESCRIPTION
"log_actor" replaced "log_user" and "log_user_text". This caused the functions using these properties to throw null values and display the logged in user's IP address or a null value instead. This PR patches this.

### Changes

* Change log_user to log_actor
* Change log_user_text to log_actor
