### PR TITLE
update haproxy.cfg to use a specific pem file

### DIFF
--- a/src/roles/haproxy/templates/haproxy.cfg.j2
+++ b/src/roles/haproxy/templates/haproxy.cfg.j2
@@ -65,7 +65,7 @@ frontend www-http
 	default_backend www-backend
 
 frontend www-https
-	bind *:443 ssl crt /etc/haproxy/certs/
+	bind *:443 ssl crt /etc/haproxy/certs/meza.pem
 	reqadd X-Forwarded-Proto:\ https
 
 	# Keep letsencrypt stuff here for now. Probably add it back later.


### PR DESCRIPTION
Users with proper certs will now need to name their proper cert "meza.pem"

### Changes

* Please provide
* a list
* of changes

### Issues

* Closes #123456789 ???
* Addresses #987654321 ???

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
