### PR TITLE
Update MezaCoreExtensions.yml

### DIFF
--- a/config/MezaCoreExtensions.yml
+++ b/config/MezaCoreExtensions.yml
@@ -299,11 +299,11 @@ list:
 #    version: "{{ mediawiki_default_branch }}"
 #    legacy_load: true
 
-  # SemanticDrilldown - Provides a page for "drilling down" through a site's data, using categories and filters on semantic properties
-  - name: SemanticDrilldown
-    repo: https://github.com/SemanticMediaWiki/SemanticDrilldown.git
-    version: master
-    legacy_load: true
+#  # SemanticDrilldown - Provides a page for "drilling down" through a site's data, using categories and filters on semantic properties
+#  - name: SemanticDrilldown
+#    repo: https://github.com/SemanticMediaWiki/SemanticDrilldown.git
+#    version: master
+#    legacy_load: true
 
   # Arrays - Creates an additional set of parser functions that operate on arrays.
   - name: Arrays

--- a/config/MezaCoreExtensions.yml
+++ b/config/MezaCoreExtensions.yml
@@ -224,12 +224,12 @@ list:
     repo: https://github.com/wikimedia/mediawiki-extensions-YouTube.git
     version: "{{ mediawiki_default_branch }}"
 
-  # ULS - Allows users to select a language and configure its support in an easy way.
-  - name: UniversalLanguageSelector
-    repo: https://github.com/wikimedia/mediawiki-extensions-UniversalLanguageSelector
-    version: "{{ mediawiki_default_branch }}"
-    config: |
-      $wgULSIMEEnabled = false;
+#  # ULS - Allows users to select a language and configure its support in an easy way.
+#  - name: UniversalLanguageSelector
+#    repo: https://github.com/wikimedia/mediawiki-extensions-UniversalLanguageSelector
+#    version: "{{ mediawiki_default_branch }}"
+#    config: |
+#      $wgULSIMEEnabled = false;
 
   # VE - Allows for editing pages as rich content
   - name: VisualEditor
@@ -507,11 +507,11 @@ list:
   # -----------------------------------------------------------------------------------------------------
   # -----------------------------------------------------------------------------------------------------
 
-  # SimpleMathJax - Enables MathJax, a JavaScript library, for typesetting TeX formula in MediaWiki inside math environments
-  - name: SimpleMathJax
-    repo: https://github.com/jamesmontalvo3/SimpleMathJax.git
-    version: e94afaffcdde8d926b166fdd166162f9519beaa1
-    legacy_load: True
+#  # SimpleMathJax - Enables MathJax, a JavaScript library, for typesetting TeX formula in MediaWiki inside math environments
+#  - name: SimpleMathJax
+#    repo: https://github.com/jamesmontalvo3/SimpleMathJax.git
+#    version: e94afaffcdde8d926b166fdd166162f9519beaa1
+#    legacy_load: True
 
   # TalkRight - Adds the 'talk' right making a permission for editing talk pages distinct from the editing of articles
   - name: TalkRight

--- a/config/MezaCoreExtensions.yml
+++ b/config/MezaCoreExtensions.yml
@@ -247,11 +247,6 @@ list:
           "Help" => true,
           "_merge_strategy" => "array_plus"
       ];
-      $wgVirtualRestConfig['modules']['parsoid'] = array(
-          'url' => "http://127.0.0.1:8080/$wikiId/rest.php",
-      );
-      // Because we're manually setting the Virtual Rest Config above, need to load Parsoid manually
-      wfLoadExtension( 'Parsoid', '{{ m_mediawiki }}/vendor/wikimedia/parsoid/extension.json' );
 
   # TemplateData - Adds a templatedata tag and an API which together allow editors to specify how templates should be invoked
   - name: TemplateData

--- a/src/roles/mediawiki/tasks/main.yml
+++ b/src/roles/mediawiki/tasks/main.yml
@@ -305,6 +305,19 @@
     - local-skins
     - latest
 
+- name: Check if the compiled_templates directory exists per the widgets extension
+  stat:
+    path: "{{ m_mediawiki }}/extensions/Widgets/compiled_templates/"
+  register: mw_ext_widgets_compiled_templates_folder
+
+- name: "Ensure compiled templates folder for widget extension is ownwed by apache"
+  file:
+    path: "{{ m_mediawiki }}/extensions/Widgets/compiled_templates/"
+    owner: apache
+    group: apache
+    mode: "0755"
+  when: mw_ext_widgets_compiled_templates_folder.stat.exists
+
 #
 # LocalSettings.php
 #


### PR DESCRIPTION
disabled Semantic Drilldown until we know where to get a 35.x compatible version from

### Changes

* Please provide
* a list
* of changes

### Issues

* Closes #123456789 ???
* Addresses #987654321 ???

### Post-merge actions

Post-merge, the following actions need to be addressed:

- [ ] Update documentation at https://www.mediawiki.org/wiki/Meza
