### PR TITLE
fix: roll back pageforms/headertabs on 35.x

### DIFF
--- a/config/MezaCoreExtensions.yml
+++ b/config/MezaCoreExtensions.yml
@@ -134,7 +134,7 @@ list:
 
   - name: PageForms
     repo: https://github.com/wikimedia/mediawiki-extensions-PageForms.git
-    version: "tags/5.4"
+    version: "tags/4.7"
     config: |
       // If enabled all "red links" will bring up a form chooser
       $wgPageFormsLinkAllRedLinksToForms = false;
@@ -324,7 +324,7 @@ list:
 
   - name: HeaderTabs
     repo: https://github.com/wikimedia/mediawiki-extensions-HeaderTabs.git
-    version: tags/2.2.1
+    version: tags/1.3
     config: |
       $wgHeaderTabsEditTabLink = false;
       $wgHeaderTabsRenderSingleTab = true;


### PR DESCRIPTION
Roll back pageforms/headertabs to versions that work on forms pulling values from namespaces

### Changes

* Roll back PageForms from 5.4 -> 4.7
* Roll back HeaderTabs from 2.2.1 -> 1.3

### Issues

* Pages that pulled values from namespaces were causing timeout issues for browsers when loaded
* These versions of the extension solves these timeout issues
