### PR TITLE
Small changes as we finish the 39.x upgrade 

### DIFF
--- a/.git-commit-template
+++ b/.git-commit-template
@@ -1,0 +1,33 @@
+#### Title; imperative, no period; ##############
+#### Limit to 50 characters #####################
+
+# Blank line between title and body
+
+# Leave the blank line above. It is critical.
+
+#######################################################################
+##### Wrap Body at 72 chars. ############# the length of this line ####
+#
+# Write your commit message in the imperative: "Fix bug" instead of 
+# "Fixed bug" or "Fixes bug."
+# 
+# Explain the problem that this commit is solving. Focus on why you
+# are making this change as opposed to how (the code explains that).
+# Are there side effects or other unintuitive consequences of this
+# change? Here's the place to explain them.
+# 
+# - Bullet points are okay, too
+# 
+# - Typically a hyphen or asterisk is used for the bullet, followed by a
+#   single space, with blank lines in between unless it's a list
+# 
+# If you use an issue tracker, put references to them at the bottom,
+# like this:
+
+# Resolves: #123
+# See also: #456, #789
+#
+# https://cbea.ms/git-commit/
+# All lines starting with the pound symbol will be discarded
+
+This work was performed for NASA GRC-ATF by WikiWorks per NASA Contract NNC15BA02B.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -157,7 +157,8 @@ Other Changes:
 * 876b8ac Major upgrade of Meza for MediaWiki 1.39
 
 ### Contributors
-* 96 Greg Rundlett
+* 89 Greg Rundlett
+* 8 Rich Evans
 
 # How to upgrade
 There is no automatic upgrade path yet from 35.x to 39.x due to the major

--- a/src/roles/saml/templates/config.php.j2
+++ b/src/roles/saml/templates/config.php.j2
@@ -75,7 +75,7 @@ $config = [
 
 	'logging.level' => SimpleSAML\Logger::NOTICE,
 	// change this handler to 'file' to get a log file in the loggingdir
-	'logging.handler' => 'syslog',
+	'logging.handler' => 'file',
 	'logging.facility' => defined('LOG_LOCAL5') ? constant('LOG_LOCAL5') : LOG_USER,
 	'logging.processname' => 'simplesamlphp',
 	'logging.logfile' => 'simplesamlphp.log',

--- a/src/roles/saml/templates/saml20-idp-remote.php.j2
+++ b/src/roles/saml/templates/saml20-idp-remote.php.j2
@@ -6,20 +6,22 @@
  *
  * See: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-idp-remote
  */
+{#
+FIXME #822: This jinja template is really hard to follow. Perhaps either
+stop offering saml_public for some of these, even though they aren't
+sensitive, or make it so the saml_secret and saml_public variables are
+merged automatically rather than on a case-by-case basis like this.
+#}
 
 {% if saml_secret.idp_entity_id is defined %}
-$metadata['{{ saml_secret.idp_entity_id }}'] = array(
+$metadata['{{ saml_secret.idp_entity_id }}'] =
 {% elif saml_public.idp_entity_id is defined %}
-$metadata['{{ saml_public.idp_entity_id }}'] = array(
+$metadata['{{ saml_public.idp_entity_id }}'] =
 {% else %}
 // neither {{ saml_secret.idp_entity_id }} nor {{ saml_public.idp_entity_id }} is defined
 {% endif %}
 
-	// FIXME #822: This jinja template is really hard to follow. Perhaps either
-	// stop offering saml_public for some of these, even though they aren't
-	// sensitive, or make it so the saml_secret and saml_public variables are
-	// merged automatically rather than on a case-by-case basis like this.
-
+[
 	{% if saml_secret.single_sign_on_service is defined %}
 	'SingleSignOnService' => '{{ saml_secret.single_sign_on_service }}',
 	{% elif saml_public.single_sign_on_service is defined %}
@@ -27,7 +29,6 @@ $metadata['{{ saml_public.idp_entity_id }}'] = array(
 	{% else %}
 	// neither {{ saml_secret.single_sign_on_service }} nor {{ saml_public.single_sign_on_service }} is defined
 	{% endif %}
-
 
 	{% if saml_secret.single_logout_service is defined %}
 	'SingleLogoutService' => '{{ saml_secret.single_logout_service }}',
@@ -37,16 +38,12 @@ $metadata['{{ saml_public.idp_entity_id }}'] = array(
 	// neither {{ saml_secret.single_logout_service }} nor {{ saml_public.single_logout_service }} is defined
 	{% endif %}
 
+	{% if saml_secret.cert_data is defined %}
+	'certData' => '{{ saml_secret.cert_data }}',
+	{% elif saml_public.cert_data is defined %}
+	'certData' => '{{ saml_public.cert_data }}',
+	{% else %}
+	// saml_public.cert_data MUST be defined; but is missing
+	{% endif %}
 
-       {% if saml_secret.cert_data is defined %}
-       'certData' => '{{ saml_secret.cert_data }}',
-
-       {% elif saml_public.cert_data is defined %}
-       'certData' => '{{ saml_public.cert_data }}',
-
-       {% else %}
-       // neither saml_secret.cert_data nor saml_public.cert_data is defined
-
-       {% endif %}
-
-);
+];


### PR DESCRIPTION
### Changes

* Add a commit template to assist commiters on formatting their commit message 
* Update the Release Notes
* Update the template for saml20-idp-remote for syntax and formatting
* Set the SAML logging handler to "file"

### Issues

* See [Upgrade Meza SAML auth (Issue #74)](https://github.com/freephile/meza/issues/74)


