### PR TITLE
Update haproxy.cfg.j2

### DIFF
--- a/src/roles/haproxy/templates/haproxy.cfg.j2
+++ b/src/roles/haproxy/templates/haproxy.cfg.j2
@@ -22,7 +22,9 @@ global
         # OBSOLETE - ssl-default-bind-options no-sslv3
 
 	ssl-default-bind-ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:EDH+aRSA:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!RC4:!DHE-RSA-CAMELLIA256-SHA:!DHE-RSA-AES256-SHA256:!DHE-RSA-AES256-SHA:!DHE-RSA-AES128-SHA256:!DHE-RSA-AES128-SHA:!DHE-RSA-SEED-SHA:!DHE-RSA-CAMELLIA128-SHA
-	ssl-default-bind-options no-sslv3 no-tlsv10 no-tlsv11 no-tlsv12
+	
+        # Per NASA-SPEC-2650 v4.0.3, section 5.1.1 - TLSv1.2 is acceptable due to interoperability with mwclient
+        ssl-default-bind-options no-sslv3 no-tlsv10 no-tlsv11
 
 	# Apache httpd.conf settings regarding SSL which we should verify if they
 	# need to be included somehow here.


### PR DESCRIPTION
Removed "no-tlsv12" in order to maintain compatibility with mwclient on RHEL8 using OpenSSL 1.1.1
