### PR TITLE
Ensure .smw.json ownership and permissions

### DIFF
--- a/config/paths.yml
+++ b/config/paths.yml
@@ -163,7 +163,7 @@ m_crond_mode: "0644"
 m_crond_owner: root
 m_crond_group: root
 
-m_config_public_mode: "0755"
+m_config_public_mode: "u=rwX,g=rwX,o=rX" # 0775 for dirs 0664 for files
 m_config_public_owner: "{{ ansible_user | default('meza-ansible') }}"
 m_config_public_group: "{{ group_wheel | default('root') }}"
 

--- a/src/roles/configure-wiki/tasks/main.yml
+++ b/src/roles/configure-wiki/tasks/main.yml
@@ -45,7 +45,7 @@
     path: "{{ m_local_public }}/wikis/{{ wiki_id }}/.smw.json"
     state: touch
     owner: "{{ user_apache }}"
-    group: "{{ group_wheel }}"
+    group: "{{ group_apache }}"
     mode: "u=rw,g=rw,o=r"
   delegate_to: localhost
   run_once: true

--- a/src/roles/init-controller-config/tasks/main.yml
+++ b/src/roles/init-controller-config/tasks/main.yml
@@ -62,15 +62,18 @@
     - file-perms
 
 
-# Still no config for controller? This must be a new installation. Copy from
-# the baseline.
+# Ensure that the 'wikis' directory exists within m_local_public; owned by 
+# apache since .smw.json needs to be writable by apache for the SMW Admin
+# Special page interface; but also group-owned by apache so that meza-ansible
+# (which is in group apache) can write to it during maintenance tasks.
 - name: "Ensure m_local_public/wikis exists"
   file:
     path: "{{ m_local_public }}/wikis"
     state: directory
-    owner: "{{ m_config_public_owner }}"
-    group: "{{ m_config_public_group }}"
+    owner: "{{ user_apache }}"
+    group: "{{ group_apache }}"
     mode: "{{ m_config_public_mode }}"
+    recurse: true
 
 - name: Ensure pre/post/saml settings directories exists in config
   file:


### PR DESCRIPTION
This fix allows not just meza deploys and command-line SMW maintenance scripts, but **ensures that the `Special:SemanticMediaWiki` Web Admin Interface works fully**.

Change the init-controller-config role to have a comment that reflects the intention of the code.

Change owner and group to apache

Make ownership of 'wikis' directory recursive

Change `m_config_public_mode` from 0755 to 0775 for dirs 0664 for files by using Symbolic mode u=rwX,g=rwX,o=rX.
Expand group permissions to be able to write files while reducing 'other' permissions to only be able to read files. Remove permission to execute files from all users.

Change the `configure-wiki` role **which only runs on wiki creation** to properly create `.smw.json` as group-owned by apache.

Fixes [Issue #44](https://github.com/freephile/meza/issues/44)
